### PR TITLE
Add optional callbacks on feature drawn and created, and pass features to callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ Optional drawing event callbacks can be added to the options. The features drawn
 ``` js
 
 // Handle onRender
-featureRenderCallback(feature) {            
+function featureRenderCallback(feature) {            
     console.log("Feature rendered:", feature);
 }
 
 // Handle onCreate
-featureCreateCallback(feature) {            
+function featureCreateCallback(feature) {            
     console.log("Feature created:", feature);
 }
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ map.addControl(new MeasuresControl(options));
 
 ```
 
+Optional drawing event callbacks can be added to the options. The features drawn will be passed to the callback. Use optional callbacks like:
+
+``` js
+
+// Handle onRender
+featureRenderCallback(feature) {            
+    console.log("Feature rendered:", feature);
+}
+
+// Handle onCreate
+featureCreateCallback(feature) {            
+    console.log("Feature created:", feature);
+}
+
+options.onRender = featureRenderCallback;
+options.onCreate = featureCreateCallback;
+
+```
+
 ### Supported Versions
 
 MapLibre GL JS 2.4  and later versions should be supported. Earlier versions probably won\'t work (not even tested anymore).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-measures",
-  "version": "0.0.10",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-measures",
-      "version": "0.0.10",
+      "version": "0.0.14",
       "license": "MIT",
       "dependencies": {
         "@mapbox/mapbox-gl-draw": "^1.4.3",

--- a/src/maplibre-gl-measures.js
+++ b/src/maplibre-gl-measures.js
@@ -1,7 +1,6 @@
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
 import * as turf from "@turf/turf";
 
-// import * as convert from "convert-units";
 import convert from 'convert-units';
 
 const DRAW_LABELS_SOURCE_ID = "source-draw-labels";
@@ -12,7 +11,6 @@ const SOURCE_DATA = {
 };
 export default class MeasuresControl {
   constructor(options) {
-    console.log("Declare new measures", convert);
     this.options = options;
     this._numberFormattingOptions = {
       minimumFractionDigits: 2,
@@ -485,7 +483,6 @@ export default class MeasuresControl {
         }
       } catch (e) {
         //Silently ignored
-        console.error(e);
       }
     });
     return {

--- a/src/maplibre-gl-measures.js
+++ b/src/maplibre-gl-measures.js
@@ -1,7 +1,8 @@
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
 import * as turf from "@turf/turf";
 
-import * as convert from "convert-units";
+// import * as convert from "convert-units";
+import convert from 'convert-units';
 
 const DRAW_LABELS_SOURCE_ID = "source-draw-labels";
 const DRAW_LABELS_LAYER_ID = "layer-draw-labels";
@@ -11,6 +12,7 @@ const SOURCE_DATA = {
 };
 export default class MeasuresControl {
   constructor(options) {
+    console.log("Declare new measures", convert);
     this.options = options;
     this._numberFormattingOptions = {
       minimumFractionDigits: 2,
@@ -483,6 +485,7 @@ export default class MeasuresControl {
         }
       } catch (e) {
         //Silently ignored
+        console.error(e);
       }
     });
     return {

--- a/src/maplibre-gl-measures.js
+++ b/src/maplibre-gl-measures.js
@@ -333,10 +333,16 @@ export default class MeasuresControl {
       this._map.on("load", () => {
         this._recreateSourceAndLayers();
       });
-      this._map.on("draw.create", this._updateLabels.bind(this));
+      this._map.on("draw.create", () => {
+        this._updateLabels();
+        this._handleOnCreate();
+      });
       this._map.on("draw.update", this._updateLabels.bind(this));
       this._map.on("draw.delete", this._updateLabels.bind(this));
-      this._map.on("draw.render", this._updateLabels.bind(this));
+      this._map.on("draw.render", () => {
+        this._updateLabels();
+        this._handleOnRender();
+      });
     }
   }
 
@@ -398,6 +404,36 @@ export default class MeasuresControl {
       // move to top
       this._map.moveLayer(DRAW_LABELS_LAYER_ID);
     }
+  }  
+
+  /**
+   * Handles the optional onRender callback provided in the options
+   */
+  _handleOnRender() {
+    if (this.options && this.options.onRender !== null && this.options.onRender !== undefined) {
+      const features = this._getDrawnFeatures();
+      // Pass drawn features to callback
+      try {
+        this.options.onRender(features);
+      } catch(e) {
+        console.error(e);
+      }
+    }
+  }
+
+  /**
+   * Handles the optional onCreate callback provided in the options
+   */
+  _handleOnCreate() {
+    if (this.options && this.options.onCreate !== null && this.options.onCreate !== undefined) {
+      const features = this._getDrawnFeatures();
+      // Pass drawn features to callback
+      try {
+        this.options.onCreate(features);
+      } catch(e) {
+        console.error(e);
+      }
+    }
   }
 
   _updateLabels() {
@@ -408,6 +444,16 @@ export default class MeasuresControl {
       source = this._map.getSource(DRAW_LABELS_SOURCE_ID);
     }
 
+    const data = this._getDrawnFeatures();
+    source.setData(data);
+    this._reorderLayers();
+  }
+
+  /**
+   * Retrieves features drawn on the map
+   * @returns {Object} A FeatureCollection of drawn features
+   */
+  _getDrawnFeatures() {
     // Build up the centroids for each segment into a features list, containing a property
     // to hold up the measurements
     let features = [];
@@ -439,13 +485,10 @@ export default class MeasuresControl {
         //Silently ignored
       }
     });
-    let data = {
+    return {
       type: "FeatureCollection",
       features: features,
     };
-    source.setData(data);
-
-    this._reorderLayers();
   }
 
   onRemove() {


### PR DESCRIPTION
Greetings,

This update adds two optional callback functions that can be passed in the options argument. On draw render and draw create events, the optional callback will pass the feature drawn. With this small change, developers will be able to greatly extend the measures tool by interacting with the features . For instance, you can grab the calculated area and display it in an input somewhere in your DOM, or you could project the feature using proj4 and apply a more accurate projection and create your own measurements using that. 

I hope the changes are to your satisfaction and meets the necessary code quality. I attempted to put this into a CodePen but I am getting errors about the measures imports. See:  https://codepen.io/g2g/pen/OJGbPRp for reference.

Please let me know if there is anything I can do to update this.

Regards,
Garret